### PR TITLE
LGCS-1045 - Piwik Organisation metadata

### DIFF
--- a/CyberHealth/CyberHealth/context_processors.py
+++ b/CyberHealth/CyberHealth/context_processors.py
@@ -2,10 +2,20 @@ from assessment.models import OrganisationRegion, OrganisationType
 
 def organisation_in_base_context(request):
     if (request.user.is_authenticated):
+        # ids
         org_region_id = request.user.organisation_set.values()[0]['organisation_region_id']
         org_type_id = request.user.organisation_set.values()[0]['organisation_type_id']
+
+        # strings
+        org_name = request.user.organisation_set.values()[0]['name']
+        org_type = OrganisationType.objects.get(pk=org_type_id).type
+        org_region = OrganisationRegion.objects.get(pk=org_region_id).name
+
         return {
-            'organisation_name': request.user.organisation_set.values()[0]['name'],
-            'organisation_type': OrganisationType.objects.get(pk=org_type_id).type,
-            'organisation_region': OrganisationRegion.objects.get(pk=org_region_id).name,
+            'organisation_name': org_name,
+            'organisation_type': org_type,
+            'organisation_region': org_region,
         }
+    else:
+        # user is not logged in: return empty dict
+        return {}

--- a/CyberHealth/CyberHealth/context_processors.py
+++ b/CyberHealth/CyberHealth/context_processors.py
@@ -2,26 +2,32 @@ from users.models import OrganisationRegion, OrganisationType
 
 def organisation_in_base_context(request):
     if (request.user.is_authenticated):
-        if len(request.user.organisation_set.values()) == 1:
-            # for users who are associated with one organisation
-            # ids
-            org_region_id = request.user.organisation_set.values()[0]['organisation_region_id']
-            org_type_id = request.user.organisation_set.values()[0]['organisation_type_id']
+        # user is logged in, get organisation details
+        # re-use from session if possible
+        session = request.session
+                
+        if session.get('organisation') is None:
+            if len(request.user.organisation_set.values()) == 1:
+                session['organisation'] = {}
+                # for users who are associated with one organisation
+                # ids
+                org_region_id = request.user.organisation_set.values()[0]['organisation_region_id']
+                org_type_id = request.user.organisation_set.values()[0]['organisation_type_id']
 
-            # strings
-            org_name = request.user.organisation_set.values()[0]['name']
-            org_type = OrganisationType.objects.get(pk=org_type_id).type
-            org_region = OrganisationRegion.objects.get(pk=org_region_id).name
+                # strings
+                session['organisation']['org_name'] = request.user.organisation_set.values()[0]['name']
+                session['organisation']['org_type'] = OrganisationType.objects.get(pk=org_type_id).type
+                session['organisation']['org_region'] = OrganisationRegion.objects.get(pk=org_region_id).name
+            else:
+                # once a user can be associated with multiple organisations, 
+                # work out which org user is logged in with
+                pass
 
-            return {
-                'organisation_name': org_name,
-                'organisation_type': org_type,
-                'organisation_region': org_region,
-            }
-        else:
-            # once a user can be associated with multiple organisations, 
-            # work out which org user is logged in with
-            pass
+        return {
+            'organisation_name': session['organisation']['org_name'],
+            'organisation_type': session['organisation']['org_type'],
+            'organisation_region': session['organisation']['org_region'],
+        }
 
 
     # no org details: return empty dict

--- a/CyberHealth/CyberHealth/context_processors.py
+++ b/CyberHealth/CyberHealth/context_processors.py
@@ -2,20 +2,27 @@ from assessment.models import OrganisationRegion, OrganisationType
 
 def organisation_in_base_context(request):
     if (request.user.is_authenticated):
-        # ids
-        org_region_id = request.user.organisation_set.values()[0]['organisation_region_id']
-        org_type_id = request.user.organisation_set.values()[0]['organisation_type_id']
+        if len(request.user.organisation_set.values()) == 1:
+            # for users who are associated with one organisation
+            # ids
+            org_region_id = request.user.organisation_set.values()[0]['organisation_region_id']
+            org_type_id = request.user.organisation_set.values()[0]['organisation_type_id']
 
-        # strings
-        org_name = request.user.organisation_set.values()[0]['name']
-        org_type = OrganisationType.objects.get(pk=org_type_id).type
-        org_region = OrganisationRegion.objects.get(pk=org_region_id).name
+            # strings
+            org_name = request.user.organisation_set.values()[0]['name']
+            org_type = OrganisationType.objects.get(pk=org_type_id).type
+            org_region = OrganisationRegion.objects.get(pk=org_region_id).name
 
-        return {
-            'organisation_name': org_name,
-            'organisation_type': org_type,
-            'organisation_region': org_region,
-        }
-    else:
-        # user is not logged in: return empty dict
-        return {}
+            return {
+                'organisation_name': org_name,
+                'organisation_type': org_type,
+                'organisation_region': org_region,
+            }
+        else:
+            # once a user can be associated with multiple organisations, 
+            # work out which org user is logged in with
+            pass
+
+
+    # no org details: return empty dict
+    return {}

--- a/CyberHealth/CyberHealth/context_processors.py
+++ b/CyberHealth/CyberHealth/context_processors.py
@@ -1,4 +1,4 @@
-from assessment.models import OrganisationRegion, OrganisationType
+from users.models import OrganisationRegion, OrganisationType
 
 def organisation_in_base_context(request):
     if (request.user.is_authenticated):

--- a/CyberHealth/CyberHealth/context_processors.py
+++ b/CyberHealth/CyberHealth/context_processors.py
@@ -1,0 +1,11 @@
+from assessment.models import OrganisationRegion, OrganisationType
+
+def organisation_in_base_context(request):
+    if (request.user.is_authenticated):
+        org_region_id = request.user.organisation_set.values()[0]['organisation_region_id']
+        org_type_id = request.user.organisation_set.values()[0]['organisation_type_id']
+        return {
+            'organisation_name': request.user.organisation_set.values()[0]['name'],
+            'organisation_type': OrganisationType.objects.get(pk=org_type_id).type,
+            'organisation_region': OrganisationRegion.objects.get(pk=org_region_id).name,
+        }

--- a/CyberHealth/CyberHealth/settings.py
+++ b/CyberHealth/CyberHealth/settings.py
@@ -90,6 +90,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'CyberHealth.context_processors.organisation_in_base_context',
             ],
             'loaders': [
                 'apptemplates.Loader',

--- a/CyberHealth/assessment/tests/views/test_all_questions.py
+++ b/CyberHealth/assessment/tests/views/test_all_questions.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from django.urls import reverse
+from users.models import Organisation
 from django.contrib.auth.models import User
 from django.test import Client
 
@@ -10,6 +11,10 @@ class AllQuestionsViewTest(TestCase):
         self.password = 'TestUser321'
         self.test_user = User.objects.create_user(username=self.username)
         self.test_user.set_password(self.password)
+
+        self.any_organisation = Organisation.objects.get(pk=1)
+        self.test_user.organisation_set.add(self.any_organisation)
+
         self.test_user.save()
         self.client = Client()
         self.client.login(username=self.username, password=self.password)

--- a/CyberHealth/assessment/tests/views/test_overview.py
+++ b/CyberHealth/assessment/tests/views/test_overview.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 from assessment.models import Pathway, PathwayGroup
+from users.models import Organisation
 from django.contrib.auth.models import User
 from django.test import Client
 
@@ -12,6 +13,10 @@ class OverviewViewTest(TestCase):
         self.password = 'TestUser321'
         self.test_user = User.objects.create_user(username=self.username)
         self.test_user.set_password(self.password)
+
+        self.any_organisation = Organisation.objects.get(pk=1)
+        self.test_user.organisation_set.add(self.any_organisation)
+
         self.test_user.save()
         self.client = Client()
         self.client.login(username=self.username, password=self.password)

--- a/CyberHealth/assessment/tests/views/test_pathway.py
+++ b/CyberHealth/assessment/tests/views/test_pathway.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from assessment.models import Pathway, PathwayGroup
 from django.contrib.auth.models import User
+from users.models import Organisation
 from django.test import Client
 
 
@@ -11,6 +12,10 @@ class PathwayViewTest(TestCase):
         self.password = 'TestUser321'
         self.test_user = User.objects.create_user(username=self.username)
         self.test_user.set_password(self.password)
+
+        self.any_organisation = Organisation.objects.get(pk=1)
+        self.test_user.organisation_set.add(self.any_organisation)
+
         self.test_user.save()
         self.client = Client()
         self.client.login(username=self.username, password=self.password)

--- a/CyberHealth/assessment/tests/views/test_question.py
+++ b/CyberHealth/assessment/tests/views/test_question.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 from assessment.models import Question, Answer, PathwayGroup, Pathway
+from users.models import Organisation
 from django.contrib.auth.models import User
 from django.test import Client
 
@@ -11,6 +12,10 @@ class QuestionViewTest(TestCase):
         self.password = 'TestUser321'
         self.test_user = User.objects.create_user(username=self.username)
         self.test_user.set_password(self.password)
+        
+        self.any_organisation = Organisation.objects.get(pk=1)
+        self.test_user.organisation_set.add(self.any_organisation)
+        
         self.test_user.save()
         self.client = Client()
         self.client.login(username=self.username, password=self.password)

--- a/CyberHealth/templates/scripts/_piwik.html
+++ b/CyberHealth/templates/scripts/_piwik.html
@@ -7,4 +7,10 @@ var qP=[];dataLayerName!=="dataLayer"&&qP.push("data_layer_name="+dataLayerName)
 tags.async=!0,tags.src="//cyberhealth.containers.piwik.pro/"+id+".js"+qPString,scripts.parentNode.insertBefore(tags,scripts);
 !function(a,n,i){a[n]=a[n]||{};for(var c=0;c<i.length;c++)!function(i){a[n][i]=a[n][i]||{},a[n][i].api=a[n][i].api||function(){var a=[].slice.call(arguments,0);"string"==typeof a[0]&&window[dataLayerName].push({event:n+"."+i+":"+a[0],parameters:[].slice.call(arguments,1)})}}(i[c])}(window,"ppms",["tm","cm"]);
 })(window, document, 'dataLayer', 'cad20f32-ad70-58af-8470-5105afad612b');
+
+dataLayer.push({
+    organisationName: "{{ organisation_name }}",
+    organisationRegion: "{{ organisation_type }}",
+    organisationType: "{{ organisation_region }}"
+});
 </script><noscript><iframe src="//cyberhealth.containers.piwik.pro/cad20f32-ad70-58af-8470-5105afad612b/noscript.html" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/CyberHealth/templates/scripts/_piwik.html
+++ b/CyberHealth/templates/scripts/_piwik.html
@@ -10,7 +10,7 @@ tags.async=!0,tags.src="//cyberhealth.containers.piwik.pro/"+id+".js"+qPString,s
 
 dataLayer.push({
     organisationName: "{{ organisation_name }}",
-    organisationRegion: "{{ organisation_type }}",
-    organisationType: "{{ organisation_region }}"
+    organisationRegion: "{{ organisation_region }}",
+    organisationType: "{{ organisation_type }}"
 });
 </script><noscript><iframe src="//cyberhealth.containers.piwik.pro/cad20f32-ad70-58af-8470-5105afad612b/noscript.html" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>


### PR DESCRIPTION
👀 see the [ticket on Jira](https://digital.dclg.gov.uk/jira/browse/LGCS-1045)

The work in this ticket:
- stores organisation information about the currently logged in user in the session in a `context_processor` as a way of making it available to the `base.html` (this is where the piwik JS is brought in!)
- passes this organisation information to the variables `organisationName`, `organisationType` and `organisationRegion` for Piwik's data layer
- [not code] configures Piwik instance to expect these variables as the values for 3 new [Custom Dimensions](https://help.piwik.pro/support/analytics-new/custom-dimension/).